### PR TITLE
Add headers support on queue publish

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,6 +68,9 @@ export default function () {
     // exchange: '',
     // mandatory: false,
     // immediate: false,
+    // headers: {
+    //   'header-1': '',
+    // },
   })
 
   const listener = function(data) { console.log('received data: ' + data) }

--- a/amqp.go
+++ b/amqp.go
@@ -25,6 +25,7 @@ type Options struct {
 type PublishOptions struct {
 	QueueName   string
 	Body        string
+	Headers     amqpDriver.Table
 	Exchange    string
 	ContentType string
 	Mandatory   bool
@@ -77,6 +78,7 @@ func (amqp *AMQP) Publish(options PublishOptions) error {
 	}()
 
 	publishing := amqpDriver.Publishing{
+		Headers:     options.Headers,
 		ContentType: options.ContentType,
 		Body:        []byte(options.Body),
 	}


### PR DESCRIPTION
## What is this PR for?

Adds headers support for the queue publish command.

Partially resolves https://github.com/grafana/xk6-amqp/issues/18

Signed-off-by: Andraz Cuderman <cuderman.andraz@gmail.com>